### PR TITLE
fix minor typo

### DIFF
--- a/doc/burps_tutorial.asc
+++ b/doc/burps_tutorial.asc
@@ -35,7 +35,7 @@ compress_tar: xz
 END
 ----
 
-The 'compres_tar' options means that we want tarballs to be compressed
+The 'compress_tar' options means that we want tarballs to be compressed
 using xz.
 
 Creating a new project


### PR DESCRIPTION
Prior to this commit, in one place mistakenly referred to the
`compres_tar` setting, which in fact it should be `compress_tar`. This
commit fixes that minor typo.
