### PR TITLE
Install container script as rmbcontainer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ all:
 install:
 	install -d $(DESTDIR)$(bindir) $(DESTDIR)$(sysconfdir)
 	install -m 755 $(BINFILES) $(DESTDIR)$(bindir)
+	install -m 755 container $(DESTDIR)$(bindir)/rbmcontainer
 	install -d $(DESTDIR)$(perldir) $(DESTDIR)$(perldir)/RBM
 	install -m 644 $(PERL_MODULE_MAIN) $(DESTDIR)$(perldir)
 	install -m 644 $(PERL_MODULES) $(DESTDIR)$(perldir)/RBM

--- a/doc/rbm_remote.asc
+++ b/doc/rbm_remote.asc
@@ -62,7 +62,7 @@ unique identifier of the current build.
 REMOTE BUILD WITH ROOTLESS CONTAINERS
 -------------------------------------
 
-rbm includes a `container` script which allows creating rootless
+rbm includes a `rbmcontainer` script which allows creating rootless
 containers (ie. creating some Linux namespaces, without requiring root
 priviledges).
 


### PR DESCRIPTION
It seems that upstream forgot to install it.
"container" name is awfully generic.